### PR TITLE
[DESIGN] css Reset + view 크기 세팅 

### DIFF
--- a/src/style/commonStyle.tsx
+++ b/src/style/commonStyle.tsx
@@ -1,0 +1,10 @@
+import { styled } from "styled-components";
+
+const Inner = styled.div`
+  max-width: 1230px;
+  margin: 0 auto;
+  padding: 0;
+  position: relative;
+`;
+
+export { Inner };

--- a/src/style/global.tsx
+++ b/src/style/global.tsx
@@ -5,11 +5,50 @@ import "./color.css";
 import "./font.css";
 
 export const GlobalStyle = createGlobalStyle`
-html {
-  margin: 0;
-  padding: 0;
-  border: 0;
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
 
 @font-face {
   font-family: NotoSansMedium;


### PR DESCRIPTION
## 이슈 번호
#11 

## 작업 내용
- [ ] css Reset 코드 추가 (더 추가해놨어요!)
- [ ] inner 1230px로 통일 (inner가 컴포넌트마다 다 다르길래 1230px로 통일하고 사용하면 좋을듯합니다.)

## 참고사항
- footer 컴포넌트를 예시

```
import {styled} from "styled-components";
import { Inner } from "@/style/commonStyle";

const Footer = () => {
  return (
    <Container>
      <Inner>Footer</Inner>
    </Container>
  );
};

const Container = styled.div`
  display: flex;
  justify-content: space-between;
  background-color: #1e1e1e;
  padding: 50px 60px 50px 60px;
  color: white;
`;

export default Footer;
```
